### PR TITLE
Build for different VTK variants

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,18 +8,26 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_build_variantegl:
+        CONFIG: linux_64_build_variantegl
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_build_variantosmesa:
+        CONFIG: linux_64_build_variantosmesa
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_build_variantqt:
+        CONFIG: linux_64_build_variantqt
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_aarch64_:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_:
         CONFIG: linux_ppc64le_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_build_variantegl.yaml
+++ b/.ci_support/linux_64_build_variantegl.yaml
@@ -1,5 +1,7 @@
 boost_cpp:
 - 1.74.0
+build_variant:
+- egl
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 flann:
 - 1.9.1
 glew:
@@ -23,12 +25,5 @@ pin_run_as_build:
     max_pin: x.x.x
   glew:
     max_pin: x.x
-  vtk:
-    max_pin: x.x.x
 target_platform:
 - linux-64
-vtk:
-- 9.1.0
-zip_keys:
-- - cdt_name
-  - docker_image

--- a/.ci_support/linux_64_build_variantosmesa.yaml
+++ b/.ci_support/linux_64_build_variantosmesa.yaml
@@ -1,13 +1,19 @@
 boost_cpp:
 - 1.74.0
 build_variant:
-- qt
+- osmesa
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2017
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 flann:
 - 1.9.1
 glew:
@@ -20,4 +26,4 @@ pin_run_as_build:
   glew:
     max_pin: x.x
 target_platform:
-- win-64
+- linux-64

--- a/.ci_support/linux_64_build_variantqt.yaml
+++ b/.ci_support/linux_64_build_variantqt.yaml
@@ -2,12 +2,18 @@ boost_cpp:
 - 1.74.0
 build_variant:
 - qt
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2017
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 flann:
 - 1.9.1
 glew:
@@ -20,4 +26,4 @@ pin_run_as_build:
   glew:
     max_pin: x.x
 target_platform:
-- win-64
+- linux-64

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -2,6 +2,8 @@ BUILD:
 - aarch64-conda_cos7-linux-gnu
 boost_cpp:
 - 1.74.0
+build_variant:
+- qt
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 flann:
 - 1.9.1
 glew:
@@ -27,9 +29,5 @@ pin_run_as_build:
     max_pin: x.x.x
   glew:
     max_pin: x.x
-  vtk:
-    max_pin: x.x.x
 target_platform:
 - linux-aarch64
-vtk:
-- 9.1.0

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,5 +1,7 @@
 boost_cpp:
 - 1.74.0
+build_variant:
+- qt
 cdt_name:
 - cos7
 channel_sources:
@@ -11,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 flann:
 - 1.9.1
 glew:
@@ -23,9 +25,5 @@ pin_run_as_build:
     max_pin: x.x.x
   glew:
     max_pin: x.x
-  vtk:
-    max_pin: x.x.x
 target_platform:
 - linux-ppc64le
-vtk:
-- 9.1.0

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -4,6 +4,8 @@ MACOSX_SDK_VERSION:
 - '10.12'
 boost_cpp:
 - 1.74.0
+build_variant:
+- qt
 channel_sources:
 - conda-forge
 channel_targets:
@@ -25,9 +27,5 @@ pin_run_as_build:
     max_pin: x.x.x
   glew:
     max_pin: x.x
-  vtk:
-    max_pin: x.x.x
 target_platform:
 - osx-64
-vtk:
-- 9.1.0

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -2,6 +2,8 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 boost_cpp:
 - 1.74.0
+build_variant:
+- qt
 channel_sources:
 - conda-forge
 channel_targets:
@@ -23,9 +25,5 @@ pin_run_as_build:
     max_pin: x.x.x
   glew:
     max_pin: x.x
-  vtk:
-    max_pin: x.x.x
 target_platform:
 - osx-arm64
-vtk:
-- 9.1.0

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -5,6 +5,8 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+# -*- mode: jinja-shell -*-
+
 set -xeuo pipefail
 export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
 source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
@@ -25,10 +27,10 @@ conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 
 CONDARC
-GET_BOA=boa
-BUILD_CMD=mambabuild
 
-conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-} -c conda-forge
+
+mamba install --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
+mamba update --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -56,7 +58,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
     ( startgroup "Validating outputs" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# -*- mode: jinja-shell -*-
+
 source .scripts/logging_utils.sh
 
 set -xe
@@ -9,7 +11,7 @@ MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
 ( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
-MINIFORGE_FILE="Miniforge3-MacOSX-$(uname -m).sh"
+MINIFORGE_FILE="Mambaforge-MacOSX-$(uname -m).sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
 rm -rf ${MINIFORGE_HOME}
 bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
@@ -18,14 +20,12 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 
 ( startgroup "Configuring conda" ) 2> /dev/null
 
-GET_BOA=boa
-BUILD_CMD=mambabuild
-
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-}
+mamba install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip boa
+mamba update -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip boa
 
 
 
@@ -59,7 +59,7 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
     EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
 fi
 
-conda $BUILD_CMD ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
+conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
 ( startgroup "Validating outputs" ) 2> /dev/null
 
 validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/README.md
+++ b/README.md
@@ -34,10 +34,24 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_64_build_variantegl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5677&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pcl-feedstock?branchName=master&jobName=linux&configuration=linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pcl-feedstock?branchName=master&jobName=linux&configuration=linux_64_build_variantegl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_build_variantosmesa</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5677&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pcl-feedstock?branchName=master&jobName=linux&configuration=linux_64_build_variantosmesa" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_build_variantqt</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5677&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pcl-feedstock?branchName=master&jobName=linux&configuration=linux_64_build_variantqt" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,15 @@
 
 set -ex
 
+EXTRA_CMAKE_ARGS=()
+
+if [[ "$build_variant" == "egl" ]]; then
+  EXTRA_CMAKE_ARGS+=(
+    "-DOPENGL_egl_LIBRARY:FILEPATH=${BUILD_PREFIX}/${HOST}/sysroot/usr/lib/libEGL.so.1"
+    "-DOPENGL_opengl_LIBRARY:FILEPATH=${BUILD_PREFIX}/${HOST}/sysroot/usr/lib64/libGL.so"
+  )
+fi
+
 cmake \
   -DCMAKE_INSTALL_PREFIX=$PREFIX \
   -DCMAKE_BUILD_TYPE=Release \
@@ -24,7 +33,7 @@ cmake \
   -DBUILD_tools=ON \
   -DBUILD_apps=OFF \
   -DBoost_NO_BOOST_CMAKE:BOOL=ON \
-  ${CMAKE_ARGS}
+  ${CMAKE_ARGS} "${EXTRA_CMAKE_ARGS[@]}"
 
 cmake --build . --config Release
 cmake --build . --config Release --target install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,7 +8,15 @@ if [[ "$build_variant" == "egl" ]]; then
   EXTRA_CMAKE_ARGS+=(
     "-DOPENGL_egl_LIBRARY:FILEPATH=${BUILD_PREFIX}/${HOST}/sysroot/usr/lib/libEGL.so.1"
     "-DOPENGL_opengl_LIBRARY:FILEPATH=${BUILD_PREFIX}/${HOST}/sysroot/usr/lib64/libGL.so"
+    "-DWITH_QT=OFF"
   )
+elif [[ "$build_variant" == "osmesa" ]]; then
+  CMAKE_ARGS+=(
+    "-DOPENGL_opengl_LIBRARY:FILEPATH=${BUILD_PREFIX}/${HOST}/sysroot/usr/lib64/libGL.so"
+    "-DWITH_QT=OFF"
+  )
+elif [[ "$build_variant" == "qt" ]]; then
+  CMAKE_ARGS+=("-DWITH_QT=ON")
 fi
 
 cmake \
@@ -26,7 +34,6 @@ cmake \
   -DWITH_PCAP=OFF \
   -DWITH_PNG=OFF \
   -DWITH_QHULL=ON \
-  -DWITH_QT=ON \
   -DWITH_VTK=ON \
   -DBUILD_global_tests=OFF \
   -DBUILD_examples=OFF \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,7 @@
-
+build_variant:
+  - "qt"
+  - "osmesa"  # [linux64]
+  - "egl"     # [linux64]
 MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
   - "10.12"                # [osx and x86_64]
 MACOSX_SDK_VERSION:        # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set name = "pcl" %}
+{% set build_number = 3 %}
 {% set version = "1.12.0" %}
 {% set major_version = version.split(".")[0] %}
 {% set minor_version = version.split(".")[1] %}
@@ -14,36 +15,38 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: {{ build_number }}
   run_exports:
     - {{ pin_subpackage('pcl', max_pin='x.x.x') }}
+  string: {{ build_variant }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ build_number }}
 
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - {{ cdt('mesa-libgl-devel') }}  # [linux]
-    - {{ cdt('mesa-dri-drivers') }}  # [linux]
-    - {{ cdt('libselinux') }}        # [linux]
-    - {{ cdt('libxdamage') }}        # [linux]
-    - {{ cdt('libxxf86vm') }}        # [linux]
-    - {{ cdt('libxext') }}           # [linux]
+    - {{ cdt('mesa-libgl-devel') }}   # [linux and build_variant != "osmesa"]
+    - {{ cdt('mesa-dri-drivers') }}   # [linux and build_variant != "osmesa"]
+    - {{ cdt('libselinux') }}         # [linux and build_variant != "osmesa"]
+    - {{ cdt('libxdamage') }}         # [linux and build_variant != "osmesa"]
+    - {{ cdt('libxxf86vm') }}         # [linux and build_variant != "osmesa"]
+    - {{ cdt('libxext') }}            # [linux and build_variant != "osmesa"]
+    - {{ cdt('mesa-libegl-devel') }}  # [build_variant == "egl"]
     - cmake
-    - ninja                          # [win]
-    - make                           # [unix]
+    - ninja                           # [win]
+    - make                            # [unix]
   host:
-    - xorg-libxfixes                 # [linux]
+    - xorg-libxfixes                  # [linux]
     - flann
     - eigen
     - boost-cpp
     - qhull
-    - vtk
-    - glew
+    - vtk * {{ build_variant }}*
+    - glew  # [build_variant == "qt"]
   run:
     - flann
     - {{ pin_compatible('boost-cpp', max_pin='x.x.x') }}
     - qhull
-    - vtk
-    - glew
+    - vtk * {{ build_variant }}*
+    - glew  # [build_variant == "qt"]
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 
 test:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This allows people to use the different VTK variants. The EGL and OSMesa variants enable usage on headless (display-less) machines such as on supercomputers.

I have successfully locally built all 3 variants 🎉

