### PR TITLE
Enable support for vtk and qt6 on Windows

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -25,8 +25,10 @@ libpng:
 pin_run_as_build:
   flann:
     max_pin: x.x.x
-qt_main:
-- '5.15'
+qhull:
+- '2020.2'
+qt6_main:
+- '6.7'
 target_platform:
 - linux-64
 vtk:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -29,8 +29,10 @@ libpng:
 pin_run_as_build:
   flann:
     max_pin: x.x.x
-qt_main:
-- '5.15'
+qhull:
+- '2020.2'
+qt6_main:
+- '6.7'
 target_platform:
 - linux-aarch64
 vtk:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -25,6 +25,8 @@ libpng:
 pin_run_as_build:
   flann:
     max_pin: x.x.x
+qhull:
+- '2020.2'
 target_platform:
 - linux-ppc64le
 vtk:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -27,8 +27,10 @@ macos_machine:
 pin_run_as_build:
   flann:
     max_pin: x.x.x
-qt_main:
-- '5.15'
+qhull:
+- '2020.2'
+qt6_main:
+- '6.7'
 target_platform:
 - osx-64
 vtk:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -27,8 +27,10 @@ macos_machine:
 pin_run_as_build:
   flann:
     max_pin: x.x.x
-qt_main:
-- '5.15'
+qhull:
+- '2020.2'
+qt6_main:
+- '6.7'
 target_platform:
 - osx-arm64
 vtk:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -17,8 +17,10 @@ libpng:
 pin_run_as_build:
   flann:
     max_pin: x.x.x
-qt_main:
-- '5.15'
+qhull:
+- '2020.2'
+qt6_main:
+- '6.7'
 target_platform:
 - win-64
 vtk:

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -20,8 +20,8 @@ cmake -G "Ninja" ^
   -DWITH_PCAP=OFF ^
   -DWITH_PNG=OFF ^
   -DWITH_QHULL=ON ^
-  -DWITH_QT=OFF ^
-  -DWITH_VTK=OFF ^
+  -DWITH_QT=QT6 ^
+  -DWITH_VTK=ON ^
   -DBUILD_global_tests=OFF ^
   -DBUILD_examples=OFF ^
   -DBUILD_tools=ON ^

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('pcl', max_pin='x.x.x') }}
 


### PR DESCRIPTION
Apparently the package was already dependent on those packages, but their support was not enabled in CMake.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
