### PR TITLE
Manually perform the vtk941 migration and remove dependency on specific qt* build variant of vtk

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -23,7 +23,7 @@ libboost_devel:
 libpng:
 - '1.6'
 pcl:
-- 1.14.1
+- 1.15.0
 qhull:
 - '2020.2'
 qt6_main:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -23,7 +23,7 @@ libboost_devel:
 libpng:
 - '1.6'
 pcl:
-- 1.14.1
+- 1.15.0
 qhull:
 - '2020.2'
 qt6_main:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -23,7 +23,7 @@ libboost_devel:
 libpng:
 - '1.6'
 pcl:
-- 1.14.1
+- 1.15.0
 qhull:
 - '2020.2'
 target_platform:

--- a/.ci_support/migrations/vtk941.yml
+++ b/.ci_support/migrations/vtk941.yml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  kind: version
+  commit_message: "Rebuild for vtk 9.4.1"
+  migration_number: 1
+migrator_ts: 1742567043.969102
+vtk_base:
+- 9.4.1
+vtk:
+- 9.4.1

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -25,7 +25,7 @@ libpng:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pcl:
-- 1.14.1
+- 1.15.0
 qhull:
 - '2020.2'
 qt6_main:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -25,7 +25,7 @@ libpng:
 macos_machine:
 - arm64-apple-darwin20.0.0
 pcl:
-- 1.14.1
+- 1.15.0
 qhull:
 - '2020.2'
 qt6_main:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -15,7 +15,7 @@ libboost_devel:
 libpng:
 - '1.6'
 pcl:
-- 1.14.1
+- 1.15.0
 qhull:
 - '2020.2'
 qt6_main:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,9 +35,6 @@ requirements:
     - libboost-devel
     - tbb-devel                      # [win]
     - qhull
-    - vtk * qt*
-    # We have also a vanilla dependency of vtk without pins so that conda-smithy correctly sets the
-    # pin from conda-forge-pinnings
     - vtk
     - libpng
     - glew
@@ -45,7 +42,6 @@ requirements:
   run:
     - flann
     - qhull
-    - vtk * qt*
     - glew
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('pcl', max_pin='x.x.x') }}
 


### PR DESCRIPTION
The upgrade to vtk 9.4.1 in unified all the different build variants `vtk * osmesa*`, `vtk * egl*` and `vtk * qt*`, so there is no need (and it is not possible) to depend on the specific `qt*` build variant of vtk when migrating to vtk 9.4.1 . The migration has been performed manually as the additional dependency on the qt* variant (that does not exists with vtk 9.4.1) made the migrator fail.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
